### PR TITLE
Fix for_each keying of inventory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ output "inventory" {
 
 
 module "azurerm_virtual_machine" {
-  for_each     = { for idx, v in local.inventory.virtual_machine : idx => v }
+  for_each     = { for idx, v in local.inventory.virtual_machine : v.name => v }
   source       = "./modules/azurerm_virtual_machine/"
   vm_name      = each.value.name
   rg           = "RG-DAASVDI-SB-DAASVDI-TEST-NE-001"


### PR DESCRIPTION
The loop through `local.inventory.virtual_machine` was using the loop index as a key for the resources created by that loop. This causes the resources to change when the order of the inventory json changes.

Instead, use the vm `name` as a key.

This way, we go from:

```
{
   1 => {...},
   2 => {...}
}
```

to:

```
{
  "TEST-VM-001" => {...},
  "TEST-VM-002" => {...}
}
```